### PR TITLE
small "fixes" from my side, see description

### DIFF
--- a/MATLAB/Convn_Tests.m
+++ b/MATLAB/Convn_Tests.m
@@ -2,24 +2,25 @@ clear all
 close all
 %% Convolution Tests
 phi = 10; % The number of species we want to test;
-size = 256;% Size we want. Can be altered.
+N = 256;% Size we want. Can be altered.  /!\ SIZE is a built-in function, avoid overwriting it as a variable
 
 rho = cell(phi,1); % Sets up empty cell arrays for density of species phi
-rho_int = zeros(size); % Sets up the integral (zeros right now) over all the species densities
+rho_int = zeros(N); % Sets up the integral (zeros right now) over all the species densities
 
 for i = 1:phi % For each species phi
-    rho{i} = rand(size,size); % We generate a random density for that species and put it in a cell array
+    rho{i} = rand(N,N); % We generate a random density for that species and put it in a cell array
     rho_int = rho_int + rho{i}; % We add it to the integral over all species 
 end
+% the for loop works, you could also consider this "trick": rho_int = sum( cat(3,rho{:}), 3 );
 
 
 
-K = Klibfunc(pi/4,phi,size); % Calls the kernel function with desired alpha and size and creates kernels for each species phi
+K = Klibfunc(pi/4,phi,N); % Calls the kernel function with desired alpha and size and creates kernels for each species phi
 
 V = cell(phi,1); % Empty cell array for advection term(s)
 
-for i = 1:phi % For each species (or direction we can look) taking the convolution
-    V{i} = convn(full(K{i}),rho_int,'same');
+for i = 1:phi % For each species (or direction we can look) taking the convolution 
+    V{i} = conv2(rho_int,K{i},'same');  %  /!\ would want to keep the same size as rho_int (kernel could be smaller), thus reorder. Sparse, if possible? conv2, not convn, after all
     % Below just helps withsome visualization
     I = mat2gray(V{i});
     figure;


### PR DESCRIPTION
1) size is a built-in function, avoid overwriting it as a variable (used N instead)
2) the for loop for integration works, you could also consider this "trick": rho_int = sum( cat(3,rho{:}), 3 );
3) conv2 instead of convn should be just fine (maybe a femto-second faster)
4) if anything, we would want to keep the same size as rho_int (kernel could be smaller), thus I reordered to have rho_int be the first argument
5) use sparse kernel, if possible? (avoid "full")?